### PR TITLE
リンクの修正を行います

### DIFF
--- a/resources/views/layouts/lp.blade.php
+++ b/resources/views/layouts/lp.blade.php
@@ -18,7 +18,7 @@
       <v-spacer></v-spacer>
       <v-btn flat href="/login">ログイン</v-btn>
       <v-btn flat href="https://docs.google.com/forms/d/e/1FAIpQLSeBSlQiP55vjp8MTmd8X3GVNn_aWIkToagXXgDfaGRKJZ1RNg/viewform">お問い合わせ</v-btn>
-      <a href="https://slack.com/oauth/authorize?client_id=306106578305.492917770354&scope=emoji:read,users.profile:write,channels:read,chat:write:bot,identity.avatar,identity.basic,identity.email,identity.team">
+      <a href="https://slack.com/oauth/authorize?client_id=306106578305.492917770354&scope=users.profile:write,channels:read,chat:write:bot">
         <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x">
       </a>
     </v-toolbar>


### PR DESCRIPTION
>Hello again,
>
>Thank you for resubmitting Nicocale. Unfortunately, the submission still doesn't include the identity.* scopes for Sign in with Slack. Those scopes should be listed in your app's OAuth & Permissions section.
>
>On your landing page, the Add to Slack button should not request the identity.* scopes. If you no longer need emoji:read, that shouldn't be included either. You can modify the URL as below:
>
> >https://slack.com/oauth/authorize?client_id=306106578305.492917770354&scope=users.profile:write,channels:read,chat:write:bot
>
>Please let me know if you have any questions before resubmitting.
>
>Best regards,
Claire

