### PR TITLE
レビューの修正

### DIFF
--- a/resources/views/layouts/lp.blade.php
+++ b/resources/views/layouts/lp.blade.php
@@ -18,7 +18,7 @@
       <v-spacer></v-spacer>
       <v-btn flat href="/login">ログイン</v-btn>
       <v-btn flat href="https://docs.google.com/forms/d/e/1FAIpQLSeBSlQiP55vjp8MTmd8X3GVNn_aWIkToagXXgDfaGRKJZ1RNg/viewform">お問い合わせ</v-btn>
-      <a href="https://slack.com/oauth/authorize?client_id=306106578305.492917770354&scope=users.profile:write,channels:read,chat:write:bot">
+      <a href="https://slack.com/oauth/authorize?client_id=306106578305.492917770354&scope=users.profile:write,channels:read,chat:write:bot&redirect_uri={{ env('APP_URL') }}/login">
         <img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x">
       </a>
     </v-toolbar>


### PR DESCRIPTION
>Thank you for updating the scopes. Everything looks correct in the submission, as well as the separation of scopes on the Add to Slack and Sign in with Slack buttons!
>
>Unfortunately, the Add to Slack flow doesn't work after clicking Authorize. Can you please check that everything is handled correctly when we redirect to your callback URL? If you don't specify a redirect_uri in the slack.com/oauth/authorize URL, we'll use whichever one is listed first in your app settings. You'll find detailed information on this here: https://api.slack.com/docs/oauth.
>
>During Sign in with Slack, we noticed you asked for identity.basic but not identity.avatar, identity.email, or identity.team. Did you want to request those as well?
>
>We're happy to keep the submission open while you take a look at this. Please let me know if you have any questions.
