### PR TITLE
レビュー対応をします

### DIFF
--- a/app/Http/Controllers/Auth/SlackAuthController.php
+++ b/app/Http/Controllers/Auth/SlackAuthController.php
@@ -11,11 +11,13 @@ class SlackAuthController extends Controller
     use AuthenticatesUsers;
 
     const AUTH_SCOPE = [
-        'identify',
+        'identity.basic',
+        'identity.team',
+        'identity.avatar',
+        'identity.email',
     ];
 
     const PERMISSION_SCOPE = [
-        'identify',
         'channels:read',
         'chat:write:bot',
         'emoji:read',

--- a/deploy.php
+++ b/deploy.php
@@ -45,12 +45,19 @@ task('deploy:notify:failed', function () {
     slack_notify('failed');
 })->desc('デプロイ失敗時に通知');
 
+task('artisan:config:clear', function () {
+    run('{{bin/php}} {{release_path}}/artisan config:clear');
+})->desc('Execute artisan config:clear');
+
 after('deploy:failed', 'deploy:unlock');
 after('deploy:failed', 'deploy:notify:failed');
 
 before('deploy:shared', 'upload:env');
 before('deploy:symlink', 'upload:key');
 before('deploy:symlink', 'artisan:migrate');
+
+after('deploy:writable', 'artisan:cache:clear');
+after('deploy:writable', 'artisan:config:clear');
 
 after('cleanup', 'deploy:notify:success');
 


### PR DESCRIPTION
>Thank you for explaining and adding identity.basic! The listed scopes are good.
>
>It's okay if you want to use all the identity.* scopes. These will need to be requested through the Sign in with Slack link: https://nicocale.app/auth/slack. As shown in my screenshot, the identify scope is requested — you need to use the identity.basic, identity.team, identity.avatar, and identity.email scopes instead.
>
>On the Add to Slack button, you'll need to include the full URL instead of only /login. For example, redirect_uri=https://nicocale.app/login.
